### PR TITLE
fix: upgrade LXD to an existing channel

### DIFF
--- a/dist/rockcraft-pack-action/index.js
+++ b/dist/rockcraft-pack-action/index.js
@@ -4213,7 +4213,7 @@ async function ensureLXD() {
         haveSnapLXD ? 'refresh' : 'install',
         'lxd',
         '--channel',
-        '5.9/stable'
+        'latest/stable'
     ]);
     core.info('Initialising LXD...');
     await exec.exec('sudo', ['lxd', 'init', '--auto']);

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -77,7 +77,7 @@ export async function ensureLXD() {
         haveSnapLXD ? 'refresh' : 'install',
         'lxd',
         '--channel',
-        '5.9/stable'
+        'latest/stable'
     ]);
     core.info('Initialising LXD...');
     await exec.exec('sudo', ['lxd', 'init', '--auto']);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -86,7 +86,7 @@ export async function ensureLXD(): Promise<void> {
     haveSnapLXD ? 'refresh' : 'install',
     'lxd',
     '--channel',
-    '5.9/stable'
+    'latest/stable'
   ])
 
   core.info('Initialising LXD...')

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -166,7 +166,7 @@ test('ensureLXD installs the snap version of LXD if needed', async () => {
     'install',
     'lxd',
     '--channel',
-    '5.9/stable'
+    'latest/stable'
   ])
   expect(execMock).toHaveBeenNthCalledWith(4, 'sudo', ['lxd', 'init', '--auto'])
 })
@@ -249,7 +249,7 @@ test('ensureLXD still calls "lxd init" if LXD is installed', async () => {
     'refresh',
     'lxd',
     '--channel',
-    '5.9/stable'
+    'latest/stable'
   ])
   expect(execMock).toHaveBeenNthCalledWith(4, 'sudo', ['lxd', 'init', '--auto'])
 })


### PR DESCRIPTION
fixes https://github.com/canonical/craft-actions/issues/6.

LXD is no longer available in 5.9/stable, so this PR is making the rockcraft action use the same LXD channel as the one used in the source [Rockcraft project](https://github.com/canonical/rockcraft/blob/main/spread.yaml#LL66C30-L66C43) - `latest/stable`.