### PR TITLE
fix ci tests and drop 18.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
   run-rockcraft-pack-action:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
+        os: [ubuntu-22.04, ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/tests/rockcraft.yaml
+++ b/tests/rockcraft.yaml
@@ -5,8 +5,6 @@ description: Building a tiny ROCK from a bare base, with just one package
 license: Apache-2.0
 build-base: ubuntu:22.04
 base: bare
-entrypoint: [/usr/bin/hello]
-cmd: [-g, "ship it!"]
 platforms:
   amd64:
 


### PR DESCRIPTION
In this PR:
 - the test rockcraft.yaml still had deprecated fields which was causing the tests to fail. Those fields have been removed.
 - also dropped 18.04 from the test matrix since it has reached end of support