### PR TITLE
Add ignoreReturnCode to check command options

### DIFF
--- a/dist/rockcraft-pack-action/index.js
+++ b/dist/rockcraft-pack-action/index.js
@@ -4133,7 +4133,7 @@ var external_fs_ = __nccwpck_require__(147);
 var external_path_ = __nccwpck_require__(17);
 // EXTERNAL MODULE: external "os"
 var external_os_ = __nccwpck_require__(37);
-;// CONCATENATED MODULE: ./lib/tools.js
+;// CONCATENATED MODULE: ./src/tools.ts
 // -*- mode: javascript; js-indent-level: 2 -*-
 
 
@@ -4178,7 +4178,7 @@ async function ensureLXDNetwork() {
         'moby-runc'
     ];
     const installedPackages = [];
-    const options = { silent: true };
+    const options = { silent: true, ignoreReturnCode: true };
     for (const mobyPackage of mobyPackages) {
         if ((await exec.exec('dpkg', ['-l', mobyPackage], options)) === 0) {
             installedPackages.push(mobyPackage);
@@ -4232,7 +4232,7 @@ async function ensureRockcraft(channel) {
     ]);
 }
 
-;// CONCATENATED MODULE: ./lib/rockcraft-pack.js
+;// CONCATENATED MODULE: ./src/rockcraft-pack.ts
 // -*- mode: javascript; js-indent-level: 2 -*-
 
 
@@ -4286,7 +4286,7 @@ class RockcraftBuilder {
     }
 }
 
-;// CONCATENATED MODULE: ./lib/rockcraft-pack-action.js
+;// CONCATENATED MODULE: ./src/rockcraft-pack-action.ts
 // -*- mode: javascript; js-indent-level: 2 -*-
 
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -42,7 +42,7 @@ export async function ensureLXDNetwork() {
         'moby-runc'
     ];
     const installedPackages = [];
-    const options = { silent: true };
+    const options = { silent: true, ignoreReturnCode: true };
     for (const mobyPackage of mobyPackages) {
         if ((await exec.exec('dpkg', ['-l', mobyPackage], options)) === 0) {
             installedPackages.push(mobyPackage);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -46,7 +46,7 @@ export async function ensureLXDNetwork(): Promise<void> {
     'moby-runc'
   ]
   const installedPackages: string[] = []
-  const options = {silent: true}
+  const options = {silent: true, ignoreReturnCode: true}
   for (const mobyPackage of mobyPackages) {
     if ((await exec.exec('dpkg', ['-l', mobyPackage], options)) === 0) {
       installedPackages.push(mobyPackage)

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -370,7 +370,6 @@ test('ensureLXDNetwork sets up iptables and warns about Docker', async () => {
   )
   expect(execMock).toHaveBeenNthCalledWith(6, 'dpkg', ['-l', 'moby-runc'], {
     ignoreReturnCode: true,
-
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(7, 'sudo', [
@@ -425,7 +424,6 @@ test('ensureLXDNetwork sets up iptables and warns only about installed packages'
   )
   expect(execMock).toHaveBeenNthCalledWith(6, 'dpkg', ['-l', 'moby-runc'], {
     ignoreReturnCode: true,
-
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(7, 'sudo', [

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -347,24 +347,30 @@ test('ensureLXDNetwork sets up iptables and warns about Docker', async () => {
     'Installed docker related packages might interfere with LXD networking: moby-runc'
   )
   expect(execMock).toHaveBeenNthCalledWith(1, 'dpkg', ['-l', 'moby-buildx'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(2, 'dpkg', ['-l', 'moby-engine'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(3, 'dpkg', ['-l', 'moby-cli'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(4, 'dpkg', ['-l', 'moby-compose'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(
     5,
     'dpkg',
     ['-l', 'moby-containerd'],
-    {silent: true}
+    {ignoreReturnCode: true, silent: true}
   )
   expect(execMock).toHaveBeenNthCalledWith(6, 'dpkg', ['-l', 'moby-runc'], {
+    ignoreReturnCode: true,
+
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(7, 'sudo', [
@@ -396,24 +402,30 @@ test('ensureLXDNetwork sets up iptables and warns only about installed packages'
       'moby-buildx,moby-engine,moby-cli,moby-compose,moby-containerd,moby-runc'
   )
   expect(execMock).toHaveBeenNthCalledWith(1, 'dpkg', ['-l', 'moby-buildx'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(2, 'dpkg', ['-l', 'moby-engine'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(3, 'dpkg', ['-l', 'moby-cli'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(4, 'dpkg', ['-l', 'moby-compose'], {
+    ignoreReturnCode: true,
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(
     5,
     'dpkg',
     ['-l', 'moby-containerd'],
-    {silent: true}
+    {ignoreReturnCode: true, silent: true}
   )
   expect(execMock).toHaveBeenNthCalledWith(6, 'dpkg', ['-l', 'moby-runc'], {
+    ignoreReturnCode: true,
+
     silent: true
   })
   expect(execMock).toHaveBeenNthCalledWith(7, 'sudo', [


### PR DESCRIPTION
When using `@actions/exec`, the `exec` function will throw an error if the command's exit code is non-zero. If a non-zero return code is expected or accepted , the `ignoreReturnCode` option should be set in the execution options.

https://github.com/actions/toolkit/blob/7b617c260dff86f8d044d5ab0425444b29fa0d18/packages/exec/src/interfaces.ts#L27-L28
```
  /** optional.  defaults to failing on non zero.  ignore will not fail leaving it up to the caller */
  ignoreReturnCode?: boolean
```