### PR TITLE
Stable rockcraft

### DIFF
--- a/src/rockcraft-pack-action.ts
+++ b/src/rockcraft-pack-action.ts
@@ -7,7 +7,7 @@ async function run(): Promise<void> {
   try {
     const projectRoot = core.getInput('path')
     core.info(`Building ROCK in "${projectRoot}"...`)
-    const rockcraftChannel = core.getInput('rockcraft-channel') || 'edge'
+    const rockcraftChannel = core.getInput('rockcraft-channel') || 'stable'
     const rockcraftPackVerbosity = core.getInput('verbosity')
 
     const builder = new RockcraftBuilder({

--- a/tests/rockcraft.yaml
+++ b/tests/rockcraft.yaml
@@ -3,7 +3,7 @@ version: latest
 summary: A tiny ROCK
 description: Building a tiny ROCK from a bare base, with just one package
 license: Apache-2.0
-build-base: ubuntu:22.04
+build-base: ubuntu@22.04
 base: bare
 platforms:
   amd64:


### PR DESCRIPTION
Default to the `stable` rockcraft channel instead of `edge`, if the channel is not provided.