### PR TITLE
Expose the rockcraft snap channel

### DIFF
--- a/rockcraft-pack/action.yml
+++ b/rockcraft-pack/action.yml
@@ -14,6 +14,12 @@ inputs:
 
       The default is 'trace'.
     default: 'trace'
+  rockcraft-channel:
+    description: >
+      Install the snap from a specific channel
+
+      If not provided, it defaults to stable.
+    default: ''
   revision:
     description: >
       Pin the snap revision to install.


### PR DESCRIPTION
I cannot use the `revision` field because the revision is tied to a specific architecture and i've got multiarchitecture builds.  Should i just wait for 1.3.0 to reach stable or can you give the action a way to build with a snap channel so i can use the `latest/candidate` channel?