### PR TITLE
fix: use lxd from "5.21/stable"

### DIFF
--- a/dist/rockcraft-pack-action/index.js
+++ b/dist/rockcraft-pack-action/index.js
@@ -20062,7 +20062,7 @@ async function ensureLXD() {
     haveSnapLXD ? "refresh" : "install",
     "lxd",
     "--channel",
-    "latest/stable"
+    "5.21/stable"
   ]);
   core.info("Initialising LXD...");
   await exec.exec("sudo", ["lxd", "init", "--auto"]);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -79,6 +79,7 @@ export async function ensureLXD(): Promise<void> {
   ])
 
   // Install a specific version of LXD that we know works well with Rockcraft
+  // (latest LTS release, tracked in 5.21/stable)
   const haveSnapLXD = await haveExecutable('/snap/bin/lxd')
   core.info('Installing LXD...')
   await exec.exec('sudo', [
@@ -86,7 +87,7 @@ export async function ensureLXD(): Promise<void> {
     haveSnapLXD ? 'refresh' : 'install',
     'lxd',
     '--channel',
-    'latest/stable'
+    '5.21/stable'
   ])
 
   core.info('Initialising LXD...')

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -166,7 +166,7 @@ test('ensureLXD installs the snap version of LXD if needed', async () => {
     'install',
     'lxd',
     '--channel',
-    'latest/stable'
+    '5.21/stable'
   ])
   expect(execMock).toHaveBeenNthCalledWith(4, 'sudo', ['lxd', 'init', '--auto'])
 })
@@ -249,7 +249,7 @@ test('ensureLXD still calls "lxd init" if LXD is installed', async () => {
     'refresh',
     'lxd',
     '--channel',
-    'latest/stable'
+    '5.21/stable'
   ])
   expect(execMock).toHaveBeenNthCalledWith(4, 'sudo', ['lxd', 'init', '--auto'])
 })


### PR DESCRIPTION
That is the currently recommended LTS release the use, and in fact the one that works with Rockcraft ("latest/stable" has issues with overlays)