### PR TITLE
feat: add input to pin lxd channel

### DIFF
--- a/rockcraft-pack/action.yml
+++ b/rockcraft-pack/action.yml
@@ -27,6 +27,12 @@ inputs:
 
       If not provided, it defaults to whatever revision is in latest/stable.
     default: ''
+  lxd-channel:
+    description: >
+      Install the snap from a specific channel
+
+      If not provided, it defaults to 5.21/stable.
+      default: '5.21/stable'
 outputs:
   rock:
     description: 'The file name of the resulting rock.'

--- a/src/rockcraft-pack-action.ts
+++ b/src/rockcraft-pack-action.ts
@@ -15,12 +15,14 @@ async function run(): Promise<void> {
       )
     }
     const rockcraftPackVerbosity = core.getInput('verbosity')
+    const lxdChannel = core.getInput('lxd-channel') || 'stable'
 
     const builder = new RockcraftBuilder({
       projectRoot,
       rockcraftChannel,
       rockcraftPackVerbosity,
-      rockcraftRevision
+      rockcraftRevision,
+      lxdChannel
     })
     await builder.pack()
     const rock = await builder.outputRock()

--- a/src/rockcraft-pack.ts
+++ b/src/rockcraft-pack.ts
@@ -13,6 +13,7 @@ interface RockcraftBuilderOptions {
   rockcraftChannel: string
   rockcraftPackVerbosity: string
   rockcraftRevision: string
+  lxdChannel: string
 }
 
 export class RockcraftBuilder {
@@ -20,11 +21,13 @@ export class RockcraftBuilder {
   rockcraftChannel: string
   rockcraftPackVerbosity: string
   rockcraftRevision: string
+  lxdChannel: string
 
   constructor(options: RockcraftBuilderOptions) {
     this.projectRoot = tools.expandHome(options.projectRoot)
     this.rockcraftChannel = options.rockcraftChannel
     this.rockcraftRevision = options.rockcraftRevision
+    this.lxdChannel = options.lxdChannel
     if (allowedVerbosity.includes(options.rockcraftPackVerbosity)) {
       this.rockcraftPackVerbosity = options.rockcraftPackVerbosity
     } else {
@@ -38,7 +41,7 @@ export class RockcraftBuilder {
   async pack(): Promise<void> {
     core.startGroup('Installing Rockcraft plus dependencies')
     await tools.ensureSnapd()
-    await tools.ensureLXD()
+    await tools.ensureLXD(this.lxdChannel)
     await tools.ensureRockcraft(this.rockcraftChannel, this.rockcraftRevision)
     core.endGroup()
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -61,7 +61,7 @@ export async function ensureLXDNetwork(): Promise<void> {
   await exec.exec('sudo', ['iptables', '-P', 'FORWARD', 'ACCEPT'])
 }
 
-export async function ensureLXD(): Promise<void> {
+export async function ensureLXD(channel: string): Promise<void> {
   const haveDebLXD = await haveExecutable('/usr/bin/lxd')
   if (haveDebLXD) {
     core.info('Removing legacy .deb packaged LXD...')
@@ -87,7 +87,7 @@ export async function ensureLXD(): Promise<void> {
     haveSnapLXD ? 'refresh' : 'install',
     'lxd',
     '--channel',
-    '5.21/stable'
+    channel
   ])
 
   core.info('Initialising LXD...')

--- a/tests/rockcraft-pack.test.ts
+++ b/tests/rockcraft-pack.test.ts
@@ -16,7 +16,8 @@ test('RockcraftBuilder expands tilde in project root', () => {
     projectRoot: '~',
     rockcraftChannel: 'edge',
     rockcraftPackVerbosity: 'trace',
-    rockcraftRevision: '1'
+    rockcraftRevision: '1',
+    lxdChannel: 'edge'
   })
   expect(builder.projectRoot).toBe(os.homedir())
 
@@ -24,7 +25,8 @@ test('RockcraftBuilder expands tilde in project root', () => {
     projectRoot: '~/foo/bar',
     rockcraftChannel: 'stable',
     rockcraftPackVerbosity: 'trace',
-    rockcraftRevision: '1'
+    rockcraftRevision: '1',
+    lxdChannel: 'stable'
   })
   expect(builder.projectRoot).toBe(path.join(os.homedir(), 'foo/bar'))
 })
@@ -54,7 +56,8 @@ test('RockcraftBuilder.pack runs a rock build', async () => {
     projectRoot: projectDir,
     rockcraftChannel: 'stable',
     rockcraftPackVerbosity: 'debug',
-    rockcraftRevision: '1'
+    rockcraftRevision: '1',
+    lxdChannel: 'stable'
   })
   await builder.pack()
 
@@ -78,7 +81,7 @@ test('RockcraftBuilder.build can set the Rockcraft channel', async () => {
     .mockImplementation(async (): Promise<void> => {})
   const ensureLXD = jest
     .spyOn(tools, 'ensureLXD')
-    .mockImplementation(async (): Promise<void> => {})
+    .mockImplementation(async (channel): Promise<void> => {})
   const ensureRockcraft = jest
     .spyOn(tools, 'ensureRockcraft')
     .mockImplementation(async (channel): Promise<void> => {})
@@ -94,7 +97,8 @@ test('RockcraftBuilder.build can set the Rockcraft channel', async () => {
     projectRoot: '.',
     rockcraftChannel: 'test-channel',
     rockcraftPackVerbosity: 'trace',
-    rockcraftRevision: ''
+    rockcraftRevision: '',
+    lxdChannel: 'test-channel'
   })
   await builder.pack()
 
@@ -125,7 +129,8 @@ test('RockcraftBuilder.build can set the Rockcraft revision', async () => {
     projectRoot: '.',
     rockcraftChannel: 'channel',
     rockcraftPackVerbosity: 'trace',
-    rockcraftRevision: '123'
+    rockcraftRevision: '123',
+    lxdChannel: 'channel'
   })
   await builder.pack()
 
@@ -156,7 +161,8 @@ test('RockcraftBuilder.build can pass known verbosity', async () => {
     projectRoot: '.',
     rockcraftChannel: 'stable',
     rockcraftPackVerbosity: 'trace',
-    rockcraftRevision: '1'
+    rockcraftRevision: '1',
+    lxdChannel: 'stable'
   })
   await builder.pack()
 
@@ -171,10 +177,44 @@ test('RockcraftBuilder.build can pass known verbosity', async () => {
       projectRoot: '.',
       rockcraftChannel: 'stable',
       rockcraftPackVerbosity: 'fake-verbosity',
-      rockcraftRevision: '1'
+      rockcraftRevision: '1',
+      lxdChannel: 'stable'
     })
   }
   expect(badBuilder).toThrow()
+})
+
+test('RockcraftBuilder.build can set the LXD channel', async () => {
+  expect.assertions(2)
+
+  const ensureSnapd = jest
+    .spyOn(tools, 'ensureSnapd')
+    .mockImplementation(async (): Promise<void> => {})
+  const ensureLXD = jest
+    .spyOn(tools, 'ensureLXD')
+    .mockImplementation(async (channel): Promise<void> => {})
+  const ensureRockcraft = jest
+    .spyOn(tools, 'ensureRockcraft')
+    .mockImplementation(async (channel): Promise<void> => {})
+  const execMock = jest
+    .spyOn(exec, 'exec')
+    .mockImplementation(
+      async (program: string, args?: string[]): Promise<number> => {
+        return 0
+      }
+    )
+
+  const builder = new build.RockcraftBuilder({
+    projectRoot: '.',
+    rockcraftChannel: 'test-channel',
+    rockcraftPackVerbosity: 'trace',
+    rockcraftRevision: '',
+    lxdChannel: 'test-lxd-channel'
+  })
+  await builder.pack()
+
+  expect(ensureLXD).toHaveBeenCalledWith('test-lxd-channel')
+  expect(ensureRockcraft).toHaveBeenCalledWith('test-channel', '')
 })
 
 test('RockcraftBuilder.outputRock fails if there are no rocks', async () => {
@@ -185,7 +225,8 @@ test('RockcraftBuilder.outputRock fails if there are no rocks', async () => {
     projectRoot: projectDir,
     rockcraftChannel: 'stable',
     rockcraftPackVerbosity: 'trace',
-    rockcraftRevision: '1'
+    rockcraftRevision: '1',
+    lxdChannel: 'stable'
   })
 
   const readdir = jest
@@ -206,7 +247,8 @@ test('RockcraftBuilder.outputRock returns the first rock', async () => {
     projectRoot: projectDir,
     rockcraftChannel: 'stable',
     rockcraftPackVerbosity: 'trace',
-    rockcraftRevision: '1'
+    rockcraftRevision: '1',
+    lxdChannel: 'stable'
   })
 
   const readdir = jest

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -145,7 +145,7 @@ test('ensureLXD installs the snap version of LXD if needed', async () => {
       }
     )
 
-  await tools.ensureLXD()
+  await tools.ensureLXD('5.21/stable')
 
   expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
     'groupadd',
@@ -192,7 +192,7 @@ test('ensureLXD removes the apt version of LXD', async () => {
       }
     )
 
-  await tools.ensureLXD()
+  await tools.ensureLXD('5.21/stable')
 
   expect(accessMock).toHaveBeenCalled()
   expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
@@ -228,7 +228,7 @@ test('ensureLXD still calls "lxd init" if LXD is installed', async () => {
       }
     )
 
-  await tools.ensureLXD()
+  await tools.ensureLXD('5.21/stable')
 
   expect(accessMock).toHaveBeenCalled()
   expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [


### PR DESCRIPTION
This PR adds new parameter lxd-channel to the
rockcraft action. The parameter defaults to
'5.21/stable' to maintain the backward compatiblity.