### PR TITLE
chore: do not refresh lxd snap if already installed

### DIFF
--- a/dist/rockcraft-pack-action/index.js
+++ b/dist/rockcraft-pack-action/index.js
@@ -20056,14 +20056,16 @@ async function ensureLXD() {
     os.userInfo().username
   ]);
   const haveSnapLXD = await haveExecutable("/snap/bin/lxd");
-  core.info("Installing LXD...");
-  await exec.exec("sudo", [
-    "snap",
-    haveSnapLXD ? "refresh" : "install",
-    "lxd",
-    "--channel",
-    "5.21/stable"
-  ]);
+  if (!haveSnapLXD) {
+    core.info("Installing LXD...");
+    await exec.exec("sudo", [
+      "snap",
+      "install",
+      "lxd",
+      "--channel",
+      "5.21/stable"
+    ]);
+  }
   core.info("Initialising LXD...");
   await exec.exec("sudo", ["lxd", "init", "--auto"]);
   await ensureLXDNetwork();

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -81,14 +81,16 @@ export async function ensureLXD(): Promise<void> {
   // Install a specific version of LXD that we know works well with Rockcraft
   // (latest LTS release, tracked in 5.21/stable)
   const haveSnapLXD = await haveExecutable('/snap/bin/lxd')
-  core.info('Installing LXD...')
-  await exec.exec('sudo', [
-    'snap',
-    haveSnapLXD ? 'refresh' : 'install',
-    'lxd',
-    '--channel',
-    '5.21/stable'
-  ])
+  if (!haveSnapLXD) {
+    core.info('Installing LXD...')
+    await exec.exec('sudo', [
+      'snap',
+      'install',
+      'lxd',
+      '--channel',
+      '5.21/stable'
+    ])
+  }
 
   core.info('Initialising LXD...')
   await exec.exec('sudo', ['lxd', 'init', '--auto'])


### PR DESCRIPTION
Install lxd snap only if it does not exist.
This allows users of rockcraft-pack action to install their preferred lxd snap.