### PR TITLE
fix: use sudo to impersonate user right

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
   run-rockcraft-pack-action:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
         revision: ['1206', '']
     runs-on: ${{ matrix.os }}
     steps:

--- a/src/rockcraft-pack.ts
+++ b/src/rockcraft-pack.ts
@@ -49,9 +49,13 @@ export class RockcraftBuilder {
     }
 
     rockcraft = `${rockcraft} ${rockcraftPackArgs.trim()}`
-    await exec.exec('sg', ['lxd', '-c', rockcraft], {
-      cwd: this.projectRoot
-    })
+    await exec.exec(
+      'sudo',
+      ['--preserve-env', '--user', tools.shellUser(), ...rockcraft.split(' ')],
+      {
+        cwd: this.projectRoot
+      }
+    )
   }
 
   // This wrapper is for the benefit of the tests, due to the crazy

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -12,6 +12,10 @@ export function expandHome(p: string): string {
   return p
 }
 
+export function shellUser(): string {
+  return os.userInfo().username
+}
+
 async function haveExecutable(path: string): Promise<boolean> {
   try {
     await fs.promises.access(path, fs.constants.X_OK)
@@ -68,14 +72,14 @@ export async function ensureLXD(): Promise<void> {
     await exec.exec('sudo', ['apt-get', 'remove', '-qy', 'lxd', 'lxd-client'])
   }
 
-  core.info(`Ensuring ${os.userInfo().username} is in the lxd group...`)
+  core.info(`Ensuring ${shellUser()} is in the lxd group...`)
   await exec.exec('sudo', ['groupadd', '--force', '--system', 'lxd'])
   await exec.exec('sudo', [
     'usermod',
     '--append',
     '--groups',
     'lxd',
-    os.userInfo().username
+    shellUser()
   ])
 
   // Install a specific version of LXD that we know works well with Rockcraft

--- a/tests/rockcraft-pack.test.ts
+++ b/tests/rockcraft-pack.test.ts
@@ -30,7 +30,9 @@ test('RockcraftBuilder expands tilde in project root', () => {
 })
 
 test('RockcraftBuilder.pack runs a rock build', async () => {
-  expect.assertions(4)
+  expect.assertions(5)
+
+  const user = 'ubuntu'
 
   const ensureSnapd = jest
     .spyOn(tools, 'ensureSnapd')
@@ -41,6 +43,9 @@ test('RockcraftBuilder.pack runs a rock build', async () => {
   const ensureRockcraft = jest
     .spyOn(tools, 'ensureRockcraft')
     .mockImplementation(async (channel): Promise<void> => {})
+  const shellUser = jest
+    .spyOn(tools, 'shellUser')
+    .mockImplementation((): string => user)
   const execMock = jest
     .spyOn(exec, 'exec')
     .mockImplementation(
@@ -61,9 +66,18 @@ test('RockcraftBuilder.pack runs a rock build', async () => {
   expect(ensureSnapd).toHaveBeenCalled()
   expect(ensureLXD).toHaveBeenCalled()
   expect(ensureRockcraft).toHaveBeenCalled()
+  expect(shellUser).toHaveBeenCalled()
   expect(execMock).toHaveBeenCalledWith(
-    'sg',
-    ['lxd', '-c', 'rockcraft pack --verbosity debug'],
+    'sudo',
+    [
+      '--preserve-env',
+      '--user',
+      user,
+      'rockcraft',
+      'pack',
+      '--verbosity',
+      'debug'
+    ],
     {
       cwd: projectDir
     }
@@ -135,6 +149,8 @@ test('RockcraftBuilder.build can set the Rockcraft revision', async () => {
 test('RockcraftBuilder.build can pass known verbosity', async () => {
   expect.assertions(2)
 
+  const user = 'ubuntu'
+
   const ensureSnapd = jest
     .spyOn(tools, 'ensureSnapd')
     .mockImplementation(async (): Promise<void> => {})
@@ -144,6 +160,9 @@ test('RockcraftBuilder.build can pass known verbosity', async () => {
   const ensureRockcraft = jest
     .spyOn(tools, 'ensureRockcraft')
     .mockImplementation(async (channel): Promise<void> => {})
+  const shellUser = jest
+    .spyOn(tools, 'shellUser')
+    .mockImplementation((): string => user)
   const execMock = jest
     .spyOn(exec, 'exec')
     .mockImplementation(
@@ -161,8 +180,16 @@ test('RockcraftBuilder.build can pass known verbosity', async () => {
   await builder.pack()
 
   expect(execMock).toHaveBeenCalledWith(
-    'sg',
-    ['lxd', '-c', 'rockcraft pack --verbosity trace'],
+    'sudo',
+    [
+      '--preserve-env',
+      '--user',
+      user,
+      'rockcraft',
+      'pack',
+      '--verbosity',
+      'trace'
+    ],
     expect.anything()
   )
 


### PR DESCRIPTION
sg requires the password on 24.04 runner to impersonate user rights and will actually replace the group for all created files as LXD. Sudo is the correct way to impersonate user rights (and access new groups).

---

Github Actions are getting timed out on 24.04 runners because of
```
Run canonical/craft-actions/rockcraft-pack@main
Building rock in "rocks/magnum-conductor"...
Warning: Rockcraft revision not provided. Installing from stable
Installing Rockcraft plus dependencies
/usr/bin/sg lxd -c rockcraft pack --verbosity trace
Password: 
Error: The operation was canceled.
```