### PR TITLE
chore(ci): bump upload-artifact in test to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         installed_rev="$(snap info rockcraft | tail -1 | awk '{print $(NF-2)}')"
         [ "$installed_rev" == "(${{ matrix.revision }})" ]
     - name: Upload rock
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: test-rock_${{ matrix.os }}
+        name: test-rock-${{ matrix.os }}-${{ matrix.revision }}
         path: ${{ steps.rockcraft.outputs.rock }}


### PR DESCRIPTION
v3 is just "deprecated" but apparently github will fail the run if it uses it.