### PR TITLE
feat: charmcraft/check-libraries action

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,55 @@ Pin Charmcraft to a specific revision. Overrides the `channel` option.
 Select a channel for LXD to be installed from. Defaults to the current recommended channel for Charmcraft.
 
 ---
+
+## charmcraft/check-libraries
+
+Check if - in the current pull request - charm libraries are updated, and add the relevant label to the PR.
+
+### Usage
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: canonical/craft-actions/charmcraft/check-libraries@main
+    with:
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+You should provide the GitHub token to the action via a secret.
+
+#### Inputs
+
+##### `path`
+
+If your Charmcraft project ("charmcraft.yaml") is not located in the root of the
+workspace, you can specify an alternative location via the `path` input
+parameter.
+
+```yaml
+steps:
+  - uses: actions/checkout@v3
+  - uses: canonical/craft-actions/charmcraft/check-libraries@main
+    with:
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+      path: path/to/project/
+```
+
+##### `okay_label`
+
+Customize the label added to a PR when `charmcraft fetch-lib` says everything is up-to-date.
+Defaults to `Charm Libraries: OK`.
+
+##### `outdated_label`
+
+Customize the label added to a PR when `charmcraft fetch-lib` says something is outdated or
+out-of-sync. Defaults to `Charm Libraries: Out of sync`.
+
+##### `charmcraft-channel`
+
+Select a channel for the Charmcraft sanp to be installed from. Defaults to `latest/stable`.
+
+---
 ## Committing code
 
 Please follow these guidelines when committing code for this project:

--- a/charmcraft/check-libraries/action.yaml
+++ b/charmcraft/check-libraries/action.yaml
@@ -1,0 +1,70 @@
+name: "Check if charm libraries are updated"
+description: >
+  Check if - in the current pull request - charm libraries are updated, 
+  and add the relevant label to the PR.
+author: "Canonical"
+inputs:
+  path:
+    description: >
+      The location of the Charmcraft project.
+
+      Defaults to the base of the repository.
+    default: '.'
+  github_token:
+    description: >
+      The GitHub token to use to update the pull requests labels.
+    required: true
+  okay_label:
+    description: >
+      PR label to indicate that charm libraries are updated to their
+      latest LIBPATCH version.
+    default: "Charm Libraries: OK"
+  outdated_label:
+    description: >
+      PR label to indicate thta charm libraries are outdated, and new
+      versions can be fetched.
+    default: "Charm Libraries: Out of sync"
+  charmcraft_channel:
+    description: Install the Charmcraft snap from a specific channel.
+    default: 'latest/stable'
+
+outputs:
+  charms:
+    description: The names of any charm files created.
+    value: ${{ steps.pack-charm.outputs.charms }}
+  charmcraft-revision:
+    description: The revision of Charmcraft used for the pack.
+    value: ${{ steps.setup.outputs.charmcraft-revision }}
+  lxd-revision:
+    description: The revision of lxd used for the pack.
+    value: ${{ steps.setup.outputs.lxd-revision }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: setup
+      shell: bash
+      env:
+        CHANNEL: ${{ inputs.charmcraft_channel }}
+      run: |
+        sudo snap install charmcraft --classic --channel="$CHANNEL"
+    - id: lib-check
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.number }}
+        OKAY: "${{ inputs.okay_label }}"
+        OUTDATED: "${{ inputs.outdated_label }}"
+      run: |
+        fetch_lib="$(charmcraft fetch-lib)"
+        # If charm libraries are not up-to-date
+        if echo "$fetch_lib" | grep -qE "not found in Charmhub|updated to version|has local changes"; then
+          gh pr edit "$PR_NUMBER" --remove-label "$OKAY" --add-label "$OUTDATED"
+        else
+          gh pr edit "$PR_NUMBER" --remove-label "$OUTDATED" --add-label "$OKAY"
+        fi
+
+branding:
+  icon: layers
+  color: orange


### PR DESCRIPTION
This action allows checking whether a charm has up-to-date charm libraries or not, only according to `LIBPATCH`. The result of `charmcraft fetch-lib` is used to determine whether the libraries are outdated/out-of-sync or not.

I don't really know what the contributing process is, but here's this PR! :)
Please let me know what you think about it: if it makes sense to have here, if it needs adjustments, and so on 🌈