### PR TITLE
fix: configure lxd for pro builds in stable

### DIFF
--- a/dist/rockcraft-pack-action/index.js
+++ b/dist/rockcraft-pack-action/index.js
@@ -69,18 +69,18 @@ var require_utils = __commonJS({
 var require_command = __commonJS({
   "node_modules/@actions/core/lib/command.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       Object.defineProperty(o, k2, { enumerable: true, get: function() {
         return m[k];
       } });
-    } : function(o, m, k, k2) {
+    }) : (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    }));
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
+    }) : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {
@@ -484,18 +484,18 @@ var init_esm_node = __esm({
 var require_file_command = __commonJS({
   "node_modules/@actions/core/lib/file-command.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       Object.defineProperty(o, k2, { enumerable: true, get: function() {
         return m[k];
       } });
-    } : function(o, m, k, k2) {
+    }) : (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    }));
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
+    }) : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {
@@ -2239,6 +2239,7 @@ var require_decodeText = __commonJS({
             return decoders.utf8;
           case "latin1":
           case "ascii":
+          // TODO: Make these a separate, strict decoder?
           case "us-ascii":
           case "iso-8859-1":
           case "iso8859-1":
@@ -2938,6 +2939,7 @@ var require_basename = __commonJS({
       for (var i = path2.length - 1; i >= 0; --i) {
         switch (path2.charCodeAt(i)) {
           case 47:
+          // '/'
           case 92:
             path2 = path2.slice(i + 1);
             return path2 === ".." || path2 === "." ? "" : path2;
@@ -4172,7 +4174,21 @@ var require_util2 = __commonJS({
           return referrerOrigin;
         }
         case "strict-origin":
+        // eslint-disable-line
+        /**
+           * 1. If referrerURL is a potentially trustworthy URL and
+           * request’s current URL is not a potentially trustworthy URL,
+           * then return no referrer.
+           * 2. Return referrerOrigin
+          */
         case "no-referrer-when-downgrade":
+        // eslint-disable-line
+        /**
+         * 1. If referrerURL is a potentially trustworthy URL and
+         * request’s current URL is not a potentially trustworthy URL,
+         * then return no referrer.
+         * 2. Return referrerOrigin
+        */
         default:
           return isNonPotentiallyTrustWorthy ? "no-referrer" : referrerOrigin;
       }
@@ -14013,7 +14029,7 @@ var require_fetch = __commonJS({
             fetchParams.controller.terminate(e);
           }
         };
-        requestBody = async function* () {
+        requestBody = (async function* () {
           try {
             for await (const bytes of request.body.stream) {
               yield* processBodyChunk(bytes);
@@ -14022,7 +14038,7 @@ var require_fetch = __commonJS({
           } catch (err) {
             processBodyError(err);
           }
-        }();
+        })();
       }
       try {
         const { body, status, statusText, headersList, socket } = await dispatch({ body: requestBody });
@@ -17587,7 +17603,7 @@ var require_undici = __commonJS({
 var require_lib = __commonJS({
   "node_modules/@actions/http-client/lib/index.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       var desc = Object.getOwnPropertyDescriptor(m, k);
       if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
@@ -17596,13 +17612,13 @@ var require_lib = __commonJS({
         } };
       }
       Object.defineProperty(o, k2, desc);
-    } : function(o, m, k, k2) {
+    }) : (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    }));
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
+    }) : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {
@@ -18702,18 +18718,18 @@ var require_summary = __commonJS({
 var require_path_utils = __commonJS({
   "node_modules/@actions/core/lib/path-utils.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       Object.defineProperty(o, k2, { enumerable: true, get: function() {
         return m[k];
       } });
-    } : function(o, m, k, k2) {
+    }) : (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    }));
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
+    }) : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {
@@ -18747,18 +18763,18 @@ var require_path_utils = __commonJS({
 var require_core = __commonJS({
   "node_modules/@actions/core/lib/core.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       Object.defineProperty(o, k2, { enumerable: true, get: function() {
         return m[k];
       } });
-    } : function(o, m, k, k2) {
+    }) : (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    }));
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
+    }) : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {
@@ -18971,18 +18987,18 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
 var require_io_util = __commonJS({
   "node_modules/@actions/io/lib/io-util.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       Object.defineProperty(o, k2, { enumerable: true, get: function() {
         return m[k];
       } });
-    } : function(o, m, k, k2) {
+    }) : (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    }));
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
+    }) : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {
@@ -19144,18 +19160,18 @@ var require_io_util = __commonJS({
 var require_io = __commonJS({
   "node_modules/@actions/io/lib/io.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       Object.defineProperty(o, k2, { enumerable: true, get: function() {
         return m[k];
       } });
-    } : function(o, m, k, k2) {
+    }) : (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    }));
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
+    }) : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {
@@ -19392,18 +19408,18 @@ var require_io = __commonJS({
 var require_toolrunner = __commonJS({
   "node_modules/@actions/exec/lib/toolrunner.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       Object.defineProperty(o, k2, { enumerable: true, get: function() {
         return m[k];
       } });
-    } : function(o, m, k, k2) {
+    }) : (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    }));
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
+    }) : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {
@@ -19876,18 +19892,18 @@ var require_toolrunner = __commonJS({
 var require_exec = __commonJS({
   "node_modules/@actions/exec/lib/exec.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       Object.defineProperty(o, k2, { enumerable: true, get: function() {
         return m[k];
       } });
-    } : function(o, m, k, k2) {
+    }) : (function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    });
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
+    }));
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    } : function(o, v) {
+    }) : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {

--- a/dist/rockcraft-pack-action/index.js
+++ b/dist/rockcraft-pack-action/index.js
@@ -20118,7 +20118,12 @@ async function ensureLXD(configurePro) {
   await exec.exec("sudo", ["lxd", "init", "--auto"]);
   if (configurePro) {
     core.info("Configuring LXD for pro rockcraft builds...");
-    await exec.exec("sudo", ["pro", "config", "set", "lxd_guest_attach=available"]);
+    await exec.exec("sudo", [
+      "pro",
+      "config",
+      "set",
+      "lxd_guest_attach=available"
+    ]);
     await exec.exec("sudo", ["snap", "restart", "lxd"]);
   }
   await ensureLXDNetwork();
@@ -20167,7 +20172,7 @@ var RockcraftBuilder = class {
     await ensureLXD(!!this.buildPro);
     await ensureRockcraft(this.rockcraftChannel, this.rockcraftRevision);
     core2.endGroup();
-    let sudoArgs = ["--user", shellUser()];
+    const sudoArgs = ["--user", shellUser()];
     let rockcraft = "rockcraft pack";
     let rockcraftPackArgs = "";
     if (this.runRockcraftTest) {

--- a/dist/rockcraft-pack-action/index.js
+++ b/dist/rockcraft-pack-action/index.js
@@ -20086,7 +20086,7 @@ async function ensureLXDNetwork() {
   );
   await exec.exec("sudo", ["iptables", "-P", "FORWARD", "ACCEPT"]);
 }
-async function ensureLXD() {
+async function ensureLXD(configurePro) {
   const haveDebLXD = await haveExecutable("/usr/bin/lxd");
   if (haveDebLXD) {
     core.info("Removing legacy .deb packaged LXD...");
@@ -20116,6 +20116,11 @@ async function ensureLXD() {
   }
   core.info("Initialising LXD...");
   await exec.exec("sudo", ["lxd", "init", "--auto"]);
+  if (configurePro) {
+    core.info("Configuring LXD for pro rockcraft builds...");
+    await exec.exec("sudo", ["pro", "config", "set", "lxd_guest_attach=available"]);
+    await exec.exec("sudo", ["snap", "restart", "lxd"]);
+  }
   await ensureLXDNetwork();
 }
 async function ensureRockcraft(channel, revision) {
@@ -20159,7 +20164,7 @@ var RockcraftBuilder = class {
   async pack() {
     core2.startGroup("Installing Rockcraft plus dependencies");
     await ensureSnapd();
-    await ensureLXD();
+    await ensureLXD(!!this.buildPro);
     await ensureRockcraft(this.rockcraftChannel, this.rockcraftRevision);
     core2.endGroup();
     let sudoArgs = ["--user", shellUser()];
@@ -20184,7 +20189,6 @@ var RockcraftBuilder = class {
           "Cannot build pro rock. This rockcraft version does not support pro."
         );
       }
-      sudoArgs = [];
       rockcraftPackArgs = `${rockcraftPackArgs} --pro=${this.buildPro}`;
     }
     if (this.rockcraftPackVerbosity) {

--- a/dist/rockcraft-pack-action/index.js
+++ b/dist/rockcraft-pack-action/index.js
@@ -69,18 +69,18 @@ var require_utils = __commonJS({
 var require_command = __commonJS({
   "node_modules/@actions/core/lib/command.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       Object.defineProperty(o, k2, { enumerable: true, get: function() {
         return m[k];
       } });
-    }) : (function(o, m, k, k2) {
+    } : function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    }));
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    }) : function(o, v) {
+    } : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {
@@ -484,18 +484,18 @@ var init_esm_node = __esm({
 var require_file_command = __commonJS({
   "node_modules/@actions/core/lib/file-command.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       Object.defineProperty(o, k2, { enumerable: true, get: function() {
         return m[k];
       } });
-    }) : (function(o, m, k, k2) {
+    } : function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    }));
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    }) : function(o, v) {
+    } : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {
@@ -2239,7 +2239,6 @@ var require_decodeText = __commonJS({
             return decoders.utf8;
           case "latin1":
           case "ascii":
-          // TODO: Make these a separate, strict decoder?
           case "us-ascii":
           case "iso-8859-1":
           case "iso8859-1":
@@ -2939,7 +2938,6 @@ var require_basename = __commonJS({
       for (var i = path2.length - 1; i >= 0; --i) {
         switch (path2.charCodeAt(i)) {
           case 47:
-          // '/'
           case 92:
             path2 = path2.slice(i + 1);
             return path2 === ".." || path2 === "." ? "" : path2;
@@ -4174,21 +4172,7 @@ var require_util2 = __commonJS({
           return referrerOrigin;
         }
         case "strict-origin":
-        // eslint-disable-line
-        /**
-           * 1. If referrerURL is a potentially trustworthy URL and
-           * request’s current URL is not a potentially trustworthy URL,
-           * then return no referrer.
-           * 2. Return referrerOrigin
-          */
         case "no-referrer-when-downgrade":
-        // eslint-disable-line
-        /**
-         * 1. If referrerURL is a potentially trustworthy URL and
-         * request’s current URL is not a potentially trustworthy URL,
-         * then return no referrer.
-         * 2. Return referrerOrigin
-        */
         default:
           return isNonPotentiallyTrustWorthy ? "no-referrer" : referrerOrigin;
       }
@@ -14029,7 +14013,7 @@ var require_fetch = __commonJS({
             fetchParams.controller.terminate(e);
           }
         };
-        requestBody = (async function* () {
+        requestBody = async function* () {
           try {
             for await (const bytes of request.body.stream) {
               yield* processBodyChunk(bytes);
@@ -14038,7 +14022,7 @@ var require_fetch = __commonJS({
           } catch (err) {
             processBodyError(err);
           }
-        })();
+        }();
       }
       try {
         const { body, status, statusText, headersList, socket } = await dispatch({ body: requestBody });
@@ -17603,7 +17587,7 @@ var require_undici = __commonJS({
 var require_lib = __commonJS({
   "node_modules/@actions/http-client/lib/index.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       var desc = Object.getOwnPropertyDescriptor(m, k);
       if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
@@ -17612,13 +17596,13 @@ var require_lib = __commonJS({
         } };
       }
       Object.defineProperty(o, k2, desc);
-    }) : (function(o, m, k, k2) {
+    } : function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    }));
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    }) : function(o, v) {
+    } : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {
@@ -18718,18 +18702,18 @@ var require_summary = __commonJS({
 var require_path_utils = __commonJS({
   "node_modules/@actions/core/lib/path-utils.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       Object.defineProperty(o, k2, { enumerable: true, get: function() {
         return m[k];
       } });
-    }) : (function(o, m, k, k2) {
+    } : function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    }));
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    }) : function(o, v) {
+    } : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {
@@ -18763,18 +18747,18 @@ var require_path_utils = __commonJS({
 var require_core = __commonJS({
   "node_modules/@actions/core/lib/core.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       Object.defineProperty(o, k2, { enumerable: true, get: function() {
         return m[k];
       } });
-    }) : (function(o, m, k, k2) {
+    } : function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    }));
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    }) : function(o, v) {
+    } : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {
@@ -18987,18 +18971,18 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
 var require_io_util = __commonJS({
   "node_modules/@actions/io/lib/io-util.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       Object.defineProperty(o, k2, { enumerable: true, get: function() {
         return m[k];
       } });
-    }) : (function(o, m, k, k2) {
+    } : function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    }));
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    }) : function(o, v) {
+    } : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {
@@ -19160,18 +19144,18 @@ var require_io_util = __commonJS({
 var require_io = __commonJS({
   "node_modules/@actions/io/lib/io.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       Object.defineProperty(o, k2, { enumerable: true, get: function() {
         return m[k];
       } });
-    }) : (function(o, m, k, k2) {
+    } : function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    }));
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    }) : function(o, v) {
+    } : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {
@@ -19408,18 +19392,18 @@ var require_io = __commonJS({
 var require_toolrunner = __commonJS({
   "node_modules/@actions/exec/lib/toolrunner.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       Object.defineProperty(o, k2, { enumerable: true, get: function() {
         return m[k];
       } });
-    }) : (function(o, m, k, k2) {
+    } : function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    }));
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    }) : function(o, v) {
+    } : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {
@@ -19892,18 +19876,18 @@ var require_toolrunner = __commonJS({
 var require_exec = __commonJS({
   "node_modules/@actions/exec/lib/exec.js"(exports2) {
     "use strict";
-    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? (function(o, m, k, k2) {
+    var __createBinding = exports2 && exports2.__createBinding || (Object.create ? function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       Object.defineProperty(o, k2, { enumerable: true, get: function() {
         return m[k];
       } });
-    }) : (function(o, m, k, k2) {
+    } : function(o, m, k, k2) {
       if (k2 === void 0) k2 = k;
       o[k2] = m[k];
-    }));
-    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? (function(o, v) {
+    });
+    var __setModuleDefault = exports2 && exports2.__setModuleDefault || (Object.create ? function(o, v) {
       Object.defineProperty(o, "default", { enumerable: true, value: v });
-    }) : function(o, v) {
+    } : function(o, v) {
       o["default"] = v;
     });
     var __importStar = exports2 && exports2.__importStar || function(mod) {

--- a/src/rockcraft-pack.ts
+++ b/src/rockcraft-pack.ts
@@ -48,7 +48,7 @@ export class RockcraftBuilder {
   async pack(): Promise<void> {
     core.startGroup('Installing Rockcraft plus dependencies')
     await tools.ensureSnapd()
-    await tools.ensureLXD()
+    await tools.ensureLXD(!!this.buildPro)
     await tools.ensureRockcraft(this.rockcraftChannel, this.rockcraftRevision)
     core.endGroup()
 
@@ -77,7 +77,6 @@ export class RockcraftBuilder {
           'Cannot build pro rock. This rockcraft version does not support pro.'
         )
       }
-      sudoArgs = []
       rockcraftPackArgs = `${rockcraftPackArgs} --pro=${this.buildPro}`
     }
 

--- a/src/rockcraft-pack.ts
+++ b/src/rockcraft-pack.ts
@@ -52,7 +52,7 @@ export class RockcraftBuilder {
     await tools.ensureRockcraft(this.rockcraftChannel, this.rockcraftRevision)
     core.endGroup()
 
-    let sudoArgs = ['--user', tools.shellUser()]
+    const sudoArgs = ['--user', tools.shellUser()]
     let rockcraft = 'rockcraft pack'
     let rockcraftPackArgs = ''
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -97,7 +97,7 @@ export async function ensureLXDNetwork(): Promise<void> {
   await exec.exec('sudo', ['iptables', '-P', 'FORWARD', 'ACCEPT'])
 }
 
-export async function ensureLXD(configurePro : boolean): Promise<void> {
+export async function ensureLXD(configurePro: boolean): Promise<void> {
   const haveDebLXD = await haveExecutable('/usr/bin/lxd')
   if (haveDebLXD) {
     core.info('Removing legacy .deb packaged LXD...')
@@ -134,7 +134,12 @@ export async function ensureLXD(configurePro : boolean): Promise<void> {
   await exec.exec('sudo', ['lxd', 'init', '--auto'])
   if (configurePro) {
     core.info('Configuring LXD for pro rockcraft builds...')
-    await exec.exec('sudo', ['pro', 'config', 'set', 'lxd_guest_attach=available'])
+    await exec.exec('sudo', [
+      'pro',
+      'config',
+      'set',
+      'lxd_guest_attach=available'
+    ])
     await exec.exec('sudo', ['snap', 'restart', 'lxd'])
   }
   await ensureLXDNetwork()

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -97,7 +97,7 @@ export async function ensureLXDNetwork(): Promise<void> {
   await exec.exec('sudo', ['iptables', '-P', 'FORWARD', 'ACCEPT'])
 }
 
-export async function ensureLXD(): Promise<void> {
+export async function ensureLXD(configurePro : boolean): Promise<void> {
   const haveDebLXD = await haveExecutable('/usr/bin/lxd')
   if (haveDebLXD) {
     core.info('Removing legacy .deb packaged LXD...')
@@ -132,6 +132,11 @@ export async function ensureLXD(): Promise<void> {
 
   core.info('Initialising LXD...')
   await exec.exec('sudo', ['lxd', 'init', '--auto'])
+  if (configurePro) {
+    core.info('Configuring LXD for pro rockcraft builds...')
+    await exec.exec('sudo', ['pro', 'config', 'set', 'lxd_guest_attach=available'])
+    await exec.exec('sudo', ['snap', 'restart', 'lxd'])
+  }
   await ensureLXDNetwork()
 }
 

--- a/tests/rockcraft-pack.test.ts
+++ b/tests/rockcraft-pack.test.ts
@@ -518,6 +518,8 @@ test('RockcraftBuilder.build can pass pro option', async () => {
     'sudo',
     [
       '--preserve-env',
+      '--user',
+      'ubuntu',
       'rockcraft',
       'pack',
       '--pro=esm-apps,esm-infra',

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -145,7 +145,7 @@ test('ensureLXD installs the snap version of LXD if needed', async () => {
       }
     )
 
-  await tools.ensureLXD()
+  await tools.ensureLXD(false)
 
   expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
     'groupadd',
@@ -173,6 +173,63 @@ test('ensureLXD installs the snap version of LXD if needed', async () => {
   expect(execMock).toHaveBeenNthCalledWith(4, 'sudo', ['lxd', 'init', '--auto'])
 })
 
+test('ensureLXD configures lxd_guest_attach if needed', async () => {
+  expect.assertions(7)
+
+  const accessMock = jest
+    .spyOn(fs.promises, 'access')
+    .mockImplementation(
+      async (
+        filename: fs.PathLike,
+        mode?: number | undefined
+      ): Promise<void> => {
+        throw new Error('not found')
+      }
+    )
+  const execMock = jest
+    .spyOn(exec, 'exec')
+    .mockImplementation(
+      async (program: string, args?: string[]): Promise<number> => {
+        return 0
+      }
+    )
+
+  await tools.ensureLXD(true)
+
+  expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
+    'groupadd',
+    '--force',
+    '--system',
+    'lxd'
+  ])
+  expect(execMock).toHaveBeenNthCalledWith(2, 'sudo', [
+    'usermod',
+    '--append',
+    '--groups',
+    'lxd',
+    os.userInfo().username
+  ])
+  expect(accessMock).toHaveBeenCalled()
+  expect(execMock).toHaveBeenNthCalledWith(3, 'sudo', [
+    'snap',
+    'install',
+    'lxd',
+    '--channel',
+    '5.21/stable',
+    '--cohort',
+    '+'
+  ])
+  expect(execMock).toHaveBeenNthCalledWith(4, 'sudo', ['lxd', 'init', '--auto'])
+
+  expect(execMock).toHaveBeenNthCalledWith(5, 'sudo', [
+    'pro',
+    'config',
+    'set',
+    'lxd_guest_attach=available'
+  ])
+  expect(execMock).toHaveBeenNthCalledWith(6, 'sudo', ['snap', 'restart', 'lxd'])
+})
+
 test('ensureLXD removes the apt version of LXD', async () => {
   expect.assertions(2)
 
@@ -194,7 +251,7 @@ test('ensureLXD removes the apt version of LXD', async () => {
       }
     )
 
-  await tools.ensureLXD()
+  await tools.ensureLXD(false)
 
   expect(accessMock).toHaveBeenCalled()
   expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [
@@ -230,7 +287,7 @@ test('ensureLXD is not refreshed if LXD is installed', async () => {
       }
     )
 
-  await tools.ensureLXD()
+  await tools.ensureLXD(false)
 
   expect(accessMock).toHaveBeenCalled()
   expect(execMock).not.toHaveBeenNthCalledWith(3, 'sudo', [
@@ -268,7 +325,7 @@ test('ensureLXD still calls "lxd init" if LXD is installed', async () => {
       }
     )
 
-  await tools.ensureLXD()
+  await tools.ensureLXD(false)
 
   expect(accessMock).toHaveBeenCalled()
   expect(execMock).toHaveBeenNthCalledWith(1, 'sudo', [

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -227,7 +227,11 @@ test('ensureLXD configures lxd_guest_attach if needed', async () => {
     'set',
     'lxd_guest_attach=available'
   ])
-  expect(execMock).toHaveBeenNthCalledWith(6, 'sudo', ['snap', 'restart', 'lxd'])
+  expect(execMock).toHaveBeenNthCalledWith(6, 'sudo', [
+    'snap',
+    'restart',
+    'lxd'
+  ])
 })
 
 test('ensureLXD removes the apt version of LXD', async () => {


### PR DESCRIPTION
Test workflow run [here](https://github.com/alesancor1/template-test/actions/runs/25386973047/job/74450871406).
* Installs rockcraft from `stable`. See [here](https://github.com/alesancor1/template-test/actions/runs/25386973047/job/74450871406#step:5:33)
* Configures LXD to use the pro token. See [here](https://github.com/alesancor1/template-test/actions/runs/25386973047/job/74450871406#step:5:26)
* Runs `rockcraft test --pro=esm-apps,esm-infra` and succeeds. See [here](https://github.com/alesancor1/template-test/actions/runs/25386973047/job/74450871406#step:5:76)