### PR TITLE
ci: run tests on all common branches

### DIFF
--- a/.github/workflows/test-charmcraft.yaml
+++ b/.github/workflows/test-charmcraft.yaml
@@ -8,6 +8,10 @@ on:
   push:
     branches:
       - main
+      - "feature/*"
+      - "hotfix/*"
+      - "release/*"
+      - "renovate/*"
 
 jobs:
   setup:

--- a/.github/workflows/test-charmcraft.yaml
+++ b/.github/workflows/test-charmcraft.yaml
@@ -12,6 +12,10 @@ on:
       - "hotfix/*"
       - "release/*"
       - "renovate/*"
+    paths:
+      - ".github/workflows/*charmcraft*"
+      - "charmcraft**"
+      - "_common/**"  # A change to a common action could affect this action.
 
 jobs:
   setup:

--- a/.github/workflows/test-snapcraft.yaml
+++ b/.github/workflows/test-snapcraft.yaml
@@ -13,6 +13,10 @@ on:
       - "hotfix/*"
       - "release/*"
       - "renovate/*"
+    paths:
+      - ".github/workflows/*snapcraft*"
+      - "snapcraft**"
+      - "_common/**"  # A change to a common action could affect this action.
 
 jobs:
   setup:

--- a/.github/workflows/test-snapcraft.yaml
+++ b/.github/workflows/test-snapcraft.yaml
@@ -9,6 +9,10 @@ on:
   push:
     branches:
       - main
+      - "feature/*"
+      - "hotfix/*"
+      - "release/*"
+      - "renovate/*"
 
 jobs:
   setup:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+      - "feature/*"
+      - "hotfix/*"
+      - "release/*"
+      - "renovate/*"
 
 jobs:
   test-action-code:


### PR DESCRIPTION
I believe that Renovate is not running on this repository because it is configured to follow these steps:

1. Create branch with version bumps
2. Wait for CI to pass on this branch
3. Open the PR once all workflows finish

However, I believe what's happening is it only sees its own workflows (the "stability days" workflow it runs) and so it assumes it's still waiting. From a Renovate log from this previous Sunday:

> Successful checks are all internal renovate/ checks, so returning 'pending' branch status