### PR TITLE
ci: test on Ubuntu 26.04 as well

### DIFF
--- a/.github/workflows/test-charmcraft.yaml
+++ b/.github/workflows/test-charmcraft.yaml
@@ -14,7 +14,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm]
+        os:
+          - ubuntu-22.04
+          - ubuntu-24.04
+          - ubuntu-26.04
+          - ubuntu-22.04-arm
+          - ubuntu-24.04-arm
+          - ubuntu-26.04-arm
         channel: [latest/candidate, latest/edge, 3.x/candidate]
         include:
           - os: ubuntu-24.04
@@ -42,7 +48,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm]
+        os:
+          - ubuntu-22.04
+          - ubuntu-24.04
+          - ubuntu-26.04
+          - ubuntu-22.04-arm
+          - ubuntu-24.04-arm
+          - ubuntu-26.04-arm
         channel: [latest/candidate, latest/edge, 3.x/candidate]
         include:
           - os: ubuntu-24.04

--- a/.github/workflows/test-snapcraft.yaml
+++ b/.github/workflows/test-snapcraft.yaml
@@ -18,8 +18,10 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-24.04
+          - ubuntu-26.04
           - ubuntu-22.04-arm
           - ubuntu-24.04-arm
+          - ubuntu-26.04-arm
           - self-hosted-linux-amd64-focal-medium
           - self-hosted-linux-ppc64el-noble-edge
           - self-hosted-linux-s390x-noble-edge
@@ -53,8 +55,10 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-24.04
+          - ubuntu-26.04
           - ubuntu-22.04-arm
           - ubuntu-24.04-arm
+          - ubuntu-26.04-arm
           - self-hosted-linux-amd64-focal-medium
           - self-hosted-linux-ppc64el-noble-edge
           - self-hosted-linux-s390x-noble-edge


### PR DESCRIPTION
This adds Ubuntu 26.04 as a testing platform for both Snapcraft and Charmcraft.

26.04 images are in preview on GitHub and we should ensure they work sooner rather than later.