### PR TITLE
fix: use new workaround for using other actions

### DIFF
--- a/charmcraft/pack/action.yaml
+++ b/charmcraft/pack/action.yaml
@@ -65,6 +65,10 @@ runs:
         channel: ${{ inputs.channel }}
         revision: ${{ inputs.revision }}
         lxd-channel: ${{ inputs.lxd-channel }}
+    - shell: bash
+      if: always()
+      run: |
+        rm -rf ./_tmp_charmcraft-pack-actions
     - uses: actions/cache@v6
       with:
         path: ${{ runner.temp }}/charmcraft_cache

--- a/charmcraft/pack/action.yaml
+++ b/charmcraft/pack/action.yaml
@@ -46,7 +46,20 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: canonical/craft-actions/charmcraft/setup@main
+    # This action is necessary as a workaround for https://github.com/actions/runner/issues/895.
+    # Since contexts cannot be used in the `uses:` key, we can't guarantee that this action will
+    # use the same branch of craft-actions to call other craft-actions workflows without just
+    # making our own local copy of the repository. See https://github.com/canonical/craft-actions/pull/45#discussion_r2586507869
+    # for a full explanation.
+    - name: Stage actions from adjacent action directory
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        mkdir -p _tmp_charmcraft-pack-actions
+        cp -r "$ACTION_PATH"/../../charmcraft \
+          _tmp_charmcraft-pack-actions/
+    - uses: ./_tmp_charmcraft-pack-actions/charmcraft/setup
       id: setup
       with:
         channel: ${{ inputs.channel }}

--- a/snapcraft/pack/action.yaml
+++ b/snapcraft/pack/action.yaml
@@ -76,6 +76,7 @@ runs:
         lxd-channel: ${{ inputs.lxd-channel }}
 
     - shell: bash
+      if: always()
       run: |
         rm -rf ./_tmp_snapcraft-pack-actions
 

--- a/snapcraft/pack/action.yaml
+++ b/snapcraft/pack/action.yaml
@@ -59,17 +59,16 @@ runs:
     # use the same branch of craft-actions to call other craft-actions workflows without just
     # making our own local copy of the repository. See https://github.com/canonical/craft-actions/pull/45#discussion_r2586507869
     # for a full explanation.
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Stage actions from adjacent action directory
+      shell: bash
       env:
-        GITHUB_REF: ${{ github.action_ref }}
-      with:
-        repository: 'canonical/craft-actions'
-        ref: ${{ env.GITHUB_REF }}
-        path: _tmp_craft-actions
-        sparse-checkout: |
-          snapcraft/
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        mkdir -p _tmp_snapcraft-pack-actions
+        cp -r "$ACTION_PATH"/../../{snapcraft,_common} \
+          _tmp_snapcraft-pack-actions/
 
-    - uses: ./_tmp_craft-actions/snapcraft/setup
+    - uses: ./_tmp_snapcraft-pack-actions/snapcraft/setup
       id: setup
       with:
         channel: ${{ inputs.channel }}
@@ -78,7 +77,7 @@ runs:
 
     - shell: bash
       run: |
-        rm -rf ./_tmp_craft-actions
+        rm -rf ./_tmp_snapcraft-pack-actions
 
     - shell: bash
       id: pack

--- a/snapcraft/setup/action.yaml
+++ b/snapcraft/setup/action.yaml
@@ -52,15 +52,14 @@ runs:
     # use the same branch of craft-actions to call other craft-actions workflows without just
     # making our own local copy of the repository. See https://github.com/canonical/craft-actions/pull/45#discussion_r2586507869
     # for a full explanation.
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Stage actions from adjacent action directory
+      shell: bash
       env:
-        GITHUB_REF: ${{ github.action_ref }}
-      with:
-        repository: 'canonical/craft-actions'
-        ref: ${{ env.GITHUB_REF }}
-        path: _tmp_craft-actions
-        sparse-checkout: |
-          _common/
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        mkdir -p _tmp_snapcraft-setup-actions
+        cp -r "$ACTION_PATH"/../../_common \
+          _tmp_snapcraft-setup-actions/
 
     - uses: canonical/setup-lxd@da2ac84e727dc534215fd14cd088b9209d65893b # main as of 6-4-26
       with:
@@ -84,13 +83,13 @@ runs:
           sudo snap $ACTION --channel=${{ inputs.channel }} --classic snapcraft
         fi
 
-    - uses: ./_tmp_craft-actions/_common/get-snap-revision
+    - uses: ./_tmp_snapcraft-setup-actions/_common/get-snap-revision
       name: Get Snapcraft revision
       id: snapcraft-revision
       with:
         snap: 'snapcraft'
 
-    - uses: ./_tmp_craft-actions/_common/get-snap-revision
+    - uses: ./_tmp_snapcraft-setup-actions/_common/get-snap-revision
       name: Get LXD revision
       id: lxd-revision
       with:
@@ -98,7 +97,7 @@ runs:
 
     - shell: bash
       run: |
-        rm -rf ./_tmp_craft-actions
+        rm -rf ./_tmp_snapcraft-setup-actions
 
 branding:
   icon: package

--- a/snapcraft/setup/action.yaml
+++ b/snapcraft/setup/action.yaml
@@ -96,6 +96,7 @@ runs:
         snap: 'lxd'
 
     - shell: bash
+      if: always()
       run: |
         rm -rf ./_tmp_snapcraft-setup-actions
 


### PR DESCRIPTION
This replaces the existing workaround which did not work with composite actions with a new one based on the workaround added to Testflinger in https://github.com/canonical/testflinger/pull/1014.

Copy to unique paths rather than to allow subsequent actions to also copy other files as needed.

Fixes #71 