### PR TITLE
ci: align policy scan inputs with starbase PR 573

### DIFF
--- a/.github/workflows/policy.yaml
+++ b/.github/workflows/policy.yaml
@@ -1,0 +1,22 @@
+name: Check policy
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - hotfix/*
+      - work/check-policy # For development
+
+jobs:
+  policy:
+    uses: canonical/starflow/.github/workflows/policy.yaml@main
+  python-scans:
+    name: Security scan
+    uses: canonical/starflow/.github/workflows/scan-python.yaml@main
+    with:
+      osv-extra-args: "--config=osv-scanner.toml"
+      osv-exclude-paths: |
+        docs
+      uv-export-no-groups: |
+        docs
+        docs-sphinx-stack

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,1 @@
+# OSV Scanner configuration


### PR DESCRIPTION
## Summary
- add `.github/workflows/policy.yaml` with the policy and python security scan jobs
- update scan-python inputs to use `osv-extra-args`, `osv-exclude-paths`, and `uv-export-no-groups`
- add `osv-scanner.toml` with the OSV scanner config placeholder

## Dependency/lockfile changes
- none required: this change only updates GitHub workflow inputs and adds a scanner config file; no runtime/package dependencies were modified.

## Validation
- `npx --yes prettier --check .github/workflows/policy.yaml`
- verified `osv-scanner.toml` content matches expected single-line placeholder
