### PR TITLE
ci: rebuild artifacts after renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,8 @@
 {
   // Configuration file for RenovateBot: https://docs.renovatebot.com/configuration-options
   extends: ["config:recommended"],
+  // This makes Renovate continue to patch PRs that have been modified by the GitHub Actions bot
+  gitIgnoredAuthors: ["github-actions[bot]@users.noreply.github.com"],
   labels: ["dependencies"],  // For convenient searching in GitHub
   packageRules: [
     {

--- a/.github/workflows/renovate-rebuild.yaml
+++ b/.github/workflows/renovate-rebuild.yaml
@@ -1,0 +1,35 @@
+name: Renovate Rebuild
+
+on:
+  push:
+    branches:
+      - "renovate/**"
+
+permissions:
+  contents: write
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: 24
+        cache: 'pnpm'
+    - name: Install dependencies
+      run: pnpm install
+    - name: Rebuild packaged code
+      run: pnpm build
+    - name: Commit and push changes
+      run: |
+        if [ -n "$(git status --porcelain)" ]; then
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: regenerate compiled files"
+          git push
+        else
+          echo "No changes to commit"
+        fi

--- a/.github/workflows/renovate-rebuild.yaml
+++ b/.github/workflows/renovate-rebuild.yaml
@@ -4,7 +4,10 @@ on:
   push:
     branches:
       - "renovate/**"
-
+    paths:
+      - "**/package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
 permissions:
   contents: write
 

--- a/.github/workflows/renovate-rebuild.yaml
+++ b/.github/workflows/renovate-rebuild.yaml
@@ -8,6 +8,7 @@ on:
       - "**/package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
+
 permissions:
   contents: write
 


### PR DESCRIPTION
When Renovate makes a PR that updates Node dependencies, the transpiled JavaScript output becomes out-of-date. This creates a new workflow that will recompile the JavaScript for Renovate.

I'm not doing this for all PRs because it would create a lot of commit noise, so humans still need to remember to compile.